### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/alecthomas/template


### PR DESCRIPTION
I just noticed that alecthomas/units#5 seems to have fixed an issue where `go mod tidy` was always trying to update `github.com/alecthomas/units` so I thought applying a similar change would fix the same issue I am having with `github.com/alecthomas/template`.